### PR TITLE
Improve transmission xacro of gripper 2f_140

### DIFF
--- a/robotiq_2f_140_gripper_visualization/package.xml
+++ b/robotiq_2f_140_gripper_visualization/package.xml
@@ -12,5 +12,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>urdf</exec_depend>
+  <exec_depend>roboticsgroup_upatras_gazebo_plugins</exec_depend>
 
 </package>

--- a/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f.gazebo.xacro
+++ b/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f.gazebo.xacro
@@ -39,4 +39,17 @@
 
     </xacro:macro>
 
+    <xacro:macro name="robotiq_gazebo_ref" params="append_prefix:=true prefix fingerprefix link color">
+        <xacro:if value="${append_prefix}">
+            <gazebo reference="${prefix}${fingerprefix}_${link}">
+                <material>${color}</material>
+            </gazebo>
+        </xacro:if>
+        <xacro:unless value="${append_prefix}">
+            <gazebo reference="${link}">
+                <material>${color}</material>
+            </gazebo>
+        </xacro:unless>
+    </xacro:macro>
+
 </robot>

--- a/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f.gazebo.xacro
+++ b/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f.gazebo.xacro
@@ -5,31 +5,31 @@
     <!-- To fix broken gripper in gazebo according to the following issue-->
     <!--https://github.com/ros-industrial/robotiq/issues/150-->
         <gazebo>
-            <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_1">
+            <plugin filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_1">
                 <joint>${prefix}finger_joint</joint>
                 <mimicJoint>${prefix}right_outer_knuckle_joint</mimicJoint>
                 <multiplier>-1.0</multiplier>
                 <offset>0.0</offset>
             </plugin>
-            <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_2">
+            <plugin filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_2">
                 <joint>${prefix}finger_joint</joint>
                 <mimicJoint>${prefix}left_inner_knuckle_joint</mimicJoint>
                 <multiplier>-1.0</multiplier>
                 <offset>0.0</offset>
             </plugin>
-            <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_3">
+            <plugin filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_3">
                 <joint>${prefix}finger_joint</joint>
                 <mimicJoint>${prefix}right_inner_knuckle_joint</mimicJoint>
                 <multiplier>-1.0</multiplier>
                 <offset>0.0</offset>
             </plugin>
-            <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_4">
+            <plugin filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_4">
                 <joint>${prefix}finger_joint</joint>
                 <mimicJoint>${prefix}left_inner_finger_joint</mimicJoint>
                 <multiplier>1.0</multiplier>
                 <offset>0.0</offset>
             </plugin>
-            <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_5">
+            <plugin filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so" name="${prefix}mimic_robotiq_140_5">
                 <joint>${prefix}finger_joint</joint>
                 <mimicJoint>${prefix}right_inner_finger_joint</mimicJoint>
                 <multiplier>1.0</multiplier>

--- a/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f.xacro
+++ b/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f.xacro
@@ -25,6 +25,8 @@
     </link>
   </xacro:macro>
 
+  <xacro:robotiq_gazebo_ref append_prefix="false" prefix="" fingerprefix="" link="robotiq_arg2f_base_link" color="Gazebo/Black"/>
+
   <xacro:macro name="finger_joints" params="prefix fingerprefix reflect">
     <xacro:outer_finger_joint prefix="${prefix}" fingerprefix="${fingerprefix}"/>
     <xacro:inner_knuckle_joint prefix="${prefix}" fingerprefix="${fingerprefix}" reflect="${reflect}"/>
@@ -34,9 +36,14 @@
 
   <xacro:macro name="finger_links" params="prefix fingerprefix stroke">
     <xacro:outer_knuckle prefix="${prefix}" fingerprefix="${fingerprefix}" stroke="${stroke}"/>
+    <xacro:robotiq_gazebo_ref prefix="${prefix}" fingerprefix="${fingerprefix}" link="outer_knuckle" color="Gazebo/Grey"/>
     <xacro:outer_finger prefix="${prefix}" fingerprefix="${fingerprefix}" stroke="${stroke}"/>
+    <xacro:robotiq_gazebo_ref prefix="${prefix}" fingerprefix="${fingerprefix}" link="outer_finger" color="Gazebo/Black"/>
     <xacro:inner_finger prefix="${prefix}" fingerprefix="${fingerprefix}" stroke="${stroke}"/>
+    <xacro:robotiq_gazebo_ref prefix="${prefix}" fingerprefix="${fingerprefix}" link="inner_finger" color="Gazebo/Grey"/>
     <xacro:inner_finger_pad prefix="${prefix}" fingerprefix="${fingerprefix}"/>
     <xacro:inner_knuckle prefix="${prefix}" fingerprefix="${fingerprefix}" stroke="${stroke}"/>
+    <xacro:robotiq_gazebo_ref prefix="${prefix}" fingerprefix="${fingerprefix}" link="inner_knuckle" color="Gazebo/Black"/>
   </xacro:macro>
+  
 </robot>

--- a/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f_140_model_macro.xacro
+++ b/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f_140_model_macro.xacro
@@ -216,13 +216,13 @@
     <xacro:finger_joints prefix="${prefix}" fingerprefix="right" reflect="-1.0"/>
   </xacro:macro>
 
-  <xacro:macro name="robotiq_arg2f_140" params="prefix">
+  <xacro:macro name="robotiq_arg2f_140" params="prefix robotiq_transmission_hw_interface">
     <xacro:robotiq_arg2f_base_link prefix="${prefix}"/>
     <xacro:finger_links prefix="${prefix}" fingerprefix="left" stroke="140"/>
     <xacro:finger_links prefix="${prefix}" fingerprefix="right" stroke="140"/>
     <xacro:finger_joint prefix="${prefix}"/>
     <xacro:right_outer_knuckle_joint prefix="${prefix}"/>
-    <xacro:robotiq_arg2f_transmission prefix="${prefix}"/>
+    <xacro:robotiq_arg2f_transmission prefix="${prefix}" hw_interface="${robotiq_transmission_hw_interface}" />
     <xacro:robotiq_arg2f_gazebo prefix="${prefix}"/>
   </xacro:macro>
 </robot>

--- a/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f_140_model_macro.xacro
+++ b/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f_140_model_macro.xacro
@@ -216,7 +216,8 @@
     <xacro:finger_joints prefix="${prefix}" fingerprefix="right" reflect="-1.0"/>
   </xacro:macro>
 
-  <xacro:macro name="robotiq_arg2f_140" params="prefix robotiq_transmission_hw_interface">
+  <xacro:macro name="robotiq_arg2f_140" params="prefix 
+    robotiq_transmission_hw_interface:=EffortJointInterface">
     <xacro:robotiq_arg2f_base_link prefix="${prefix}"/>
     <xacro:finger_links prefix="${prefix}" fingerprefix="left" stroke="140"/>
     <xacro:finger_links prefix="${prefix}" fingerprefix="right" stroke="140"/>

--- a/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f_transmission.xacro
+++ b/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f_transmission.xacro
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-  <xacro:macro name="robotiq_arg2f_transmission" params="prefix">
+  <xacro:macro name="robotiq_arg2f_transmission" params="prefix hw_interface">
     <transmission name="${prefix}finger_joint_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}finger_joint">
-        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
-        <!--<hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>-->
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}finger_joint_motor">
         <mechanicalReduction>1</mechanicalReduction>


### PR DESCRIPTION
Improvements created
- commit https://github.com/L-eonor/robotiq/commit/354d3370ccf2a76fa3f49a085641abc0e06c1a8c

  - This enables the hardware_interface to be passed as an argument to the xacro and then change in the launch file. The modification was created based on the [ur_transmission_xacro](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur.transmission.xacro) (e.g lines [4](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur.transmission.xacro#L4 ) and [9](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur.transmission.xacro#L9)) and the [ur5.urdf.xacro](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur5.urdf.xacro) (lines [24](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur5.urdf.xacro#L24) and [358](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur5.urdf.xacro#L358)), [ur5_robot.urdf.xacro](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur5_robot.urdf.xacro) (lines [5](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur5_robot.urdf.xacro#L5) and [15](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/urdf/ur5_robot.urdf.xacro#L15)) and finally [ur5_upload.launch](https://github.com/ros-industrial/universal_robot/blob/kinetic-devel/ur_description/launch/ur5_upload.launch)

- commit https://github.com/L-eonor/robotiq/commit/b1a9c8b51f5d9c8cb9b7acac90043d4940a062ca
  - Update  `libroboticsgroup_gazebo_mimic_joint_plugin` because it is deprecated and changed to [roboticsgroup_upatras_gazebo_plugins](https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins)

-  commit https://github.com/L-eonor/robotiq/pull/1/commits/259106af59046033fbf802468aa5879c67a07390
   - Show gripper color in Gazebo as explained in [URDF in Gazebo](http://gazebosim.org/tutorials/?tut=ros_urdf#Materials:Usingpropercolorsandtextures)

I tested the changes in the ROS Melodic and Gazebo 9 using the gripper on the UR5 arm as you can see in [ur5_simulation](https://github.com/mateusmenezes95/ur5_simulation) repository. I tested also using `PositionJointInterface` as the hardware interface based on [mimic_joint_gazebo_tutorial](https://github.com/mintar/mimic_joint_gazebo_tutorial) and ran smoothly. It's even better to test using `PositionJointInterface` because it's possible to use `rqt_joint_trajectory_controller` gui.